### PR TITLE
Add an additional job template naming standard validation using static prefixes

### DIFF
--- a/10.Enforce multiple policies.md
+++ b/10.Enforce multiple policies.md
@@ -1,0 +1,91 @@
+# 1. Restrict use of an Inventory to a particular Organization
+
+## Overview
+
+Ansible Automation Platform allows users to enforce policies at multiple enforcement points, including:
+
+* **Organization Level:** Affects all job templates within an Organization.
+* **Inventory Level:** Affects all jobs using a specified Inventory.
+* **Job Template Level:** Affects jobs launched from a specific Job Template.
+
+However, as each enforcement point only allows for a single policy, combining multiple policies needs to be done on the policy server side to provide a single endpoint. This example covers the aforementioned use case.
+
+## Example Policy [aap_policy_examples/multistep_policy.rego](aap_policy_examples/multistep_policy.rego):
+
+The following policy (`multistep_policy.rego`) combines two already existing policies, the job template naming convention (`jt_naming_validation.rego`) and the project scm branch (`project_scm_branch.rego`) into a single policy that can be applied through Ansible Automation Platform.
+
+```rego
+# This policy combines two existing policies, the jt_naming_validation and the project_scm_branch_validation policy into a single policy to be enforced
+package multistep
+
+import data.aap_policy_examples.jt_naming_validation as job_template_name
+import data.aap_policy_examples.project_scm_branch_validation as branch
+
+default allowed = false
+
+allowed if {
+    trace(sprintf("job_template_name.allowed: %v", [job_template_name.allowed]))
+    trace(sprintf("branch.allowed: %v", [branch.allowed]))
+    job_template_name.allowed
+    branch.allowed
+}
+
+multistep_validation := result if {
+    result := {
+        "allowed": allowed,
+        "violations": array.concat(job_template_name.violations, branch.violations)
+    }
+}
+
+```
+
+## Enforcement Behavior
+
+When applied at different enforcement points, this policy prevents job execution accordingly:
+
+- **Job Template:** All jobs launched from the template will **ERROR**, preventing playbook execution.
+- **Inventory:** All jobs using the inventory will **ERROR**, preventing playbook, preventing playbook execution.
+- **Organization:** All jobs launch from job template that belongs to the organization will **ERROR**, preventing playbook execution.
+
+This policy can be used at any level, and depends on how organizations are used in your Ansible Automation Platform instance, and how configuration management of the platform is enforced.
+
+## Try It Yourself
+
+Take advantage of the [Rego playground](https://play.openpolicyagent.org/)!
+
+## Real World Use Case: Manage rego policy application
+
+### Scenario  
+
+As policy becomes more complex, administrators need to be able to manage their policies.  Reusability of policies across enforcement points becomes a core component of managing policy at scale.  Building piecewise blocks to create policies once would ease the administrative burden of managing policies.
+
+### Approach
+
+Consider a large environment with numerous organizations and teams.  The rego system administrators could create a handful of core policies that apply to everyone within their company, such as
+* Enforce a job template naming convention
+* Forbid superusers from running automation jobs
+
+Additionally, team policies, such as for the ops team, could be created around policies that change at this level, such as
+* Github repo validations
+* Inventory usage restrictions
+
+Finally, lifecycle-stage policies would be created, which would be differing based on dev, test or prod environments, such as
+* Project SCM branch enforcement
+* Maintenance windows
+
+Enforcing multiple policies can be chained.  This could look like (symbolically)
+
+```
+└── Ops_production_policy.rego
+    ├── company_policy.rego
+    │   ├── jt_naming_validation.rego
+    │   └── superuser_allowed_false.rego
+    ├── ops_policy.rego
+    │   ├── github_repo_validation.rego
+    │   └── restrict_inv_use_to_org.rego
+    └── ops_production.rego
+        ├── maintenance_window.rego
+        └── project_scm_branch.rego
+```
+
+This approach allows for easier management of the policies, where policies are written once and reused for different teams, environments, etc.

--- a/8.Enforce Job Template Naming Standards.md
+++ b/8.Enforce Job Template Naming Standards.md
@@ -12,7 +12,7 @@ This example demonstrates how to prevent job execution using Open Policy Agent (
 
 ## Example Policy [aap_policy_examples/jt_naming_validation.rego](aap_policy_examples/jt_naming_validation.rego):
 
-The following policy (`aap_policy_examples/allowed_false.rego`) blocks job execution entirely unless the Job Template name matches our standards. In this particular rule will enforce the convention '**OrganizationName_ProjectName_JobTemplateName**':
+The following policy (`aap_policy_examples/jt_naming_validation.rego`) blocks job execution entirely unless the Job Template name matches our standards. In this particular rule will enforce the convention '**OrganizationName_ProjectName_JobTemplateName**':
 
 ```rego
 package aap_policy_examples

--- a/8.Enforce Job Template Naming Standards.md
+++ b/8.Enforce Job Template Naming Standards.md
@@ -45,6 +45,11 @@ jt_naming_validation := result if {
 }
 ```
 
+## Alternate Policy [aap_policy_examples/jt_naming_validation_alternate.rego](aap_policy_examples/jt_naming_validation_alternate.rego)
+
+An alternate policy that enforces a convention of '**\<Keyword\> JobTemplateName**' has been provided, with the keywords "DEV", "TEST", "PROD", and "ALL" preconfigured.
+
+
 ## Enforcement Behavior
 
 When applied at different enforcement points, this policy prevents job execution accordingly:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Policy as Code allows you to define and enforce policies across your Ansible Aut
 
 - Ansible Automation Platform 2.5 or later with the `FEATURE_POLICY_AS_CODE_ENABLED` feature flag set to `True` 
   - see [Enabling Policy as Code Feature](docs/Enabling%20Policy%20as%20Code%20feature.md) for more information
+  - Note that this flag is enabled by default for Ansible Automation Platform 2.6 and later
 - An OPA server that's reachable from your AAP deployment
   - See [Deploy OPA server on OpenShift](docs/Deploy%20OPA%20server%20on%20OpenShift.md) for development and testing setup
   - See [Deploy OPA server with Podman](docs/Deploy%20OPA%20server%20with%20Podman.md) for development and testing setup
@@ -53,6 +54,7 @@ The repository includes several example policies demonstrating different use cas
    - [Only allow approved Github source repo branches](7b.Only%20allow%20certain%20Git%20branches.md) - Only allow approved source repo branches
 8. [Enforce Naming Standards](8.Enforce%20Job%20Template%20Naming%20Standards.md) - ensure Job Template name conforms to our standards
 9. [Restrict usage of an Inventory to an Organization](9.Restrict%20Inventory%20use%20to%20an%20organization.md) - restrict inventory usage by organization
+10. [Enforce multiple policies](10.Enforce%20multiple%20policies.md) - Chain multiple policies together for use in AAP
 
 Each policy example includes:
 - Detailed explanation of the use case

--- a/aap_policy_examples/jt_naming_validation_alternate.rego
+++ b/aap_policy_examples/jt_naming_validation_alternate.rego
@@ -1,0 +1,20 @@
+package aap_policy_examples
+
+import rego.v1
+
+allowed_keywords := {"DEV", "TEST", "PROD", "ALL"}
+
+default job_template_name := {
+    "allowed": true,
+    "violations": [],
+}
+
+job_template_name := result if {
+    jt_name := object.get(input, ["job_template", "name"], "")
+    keyword := allowed_keywords[_]
+    startswith(jt_name, keyword)
+    result := {
+        "allowed": false,
+        "violations": [sprintf("Job template naming for '%v' does not comply with standards", [jt_name])]
+    }
+}

--- a/aap_policy_examples/jt_naming_validation_alternate.rego
+++ b/aap_policy_examples/jt_naming_validation_alternate.rego
@@ -1,3 +1,5 @@
+# This is an alternate approach for enforcing a job template naming validation using fixed, allowed keywords.
+# Documentation for this alternate policy is in the 8.Enforce Job Template Naming Standards document
 package aap_policy_examples
 
 import rego.v1

--- a/aap_policy_examples/multistep_policy.rego
+++ b/aap_policy_examples/multistep_policy.rego
@@ -1,0 +1,21 @@
+# This policy combines two existing policies, the jt_naming_validation and the project_scm_branch_validation policy into a single policy to be enforced
+package multistep
+
+import data.aap_policy_examples.jt_naming_validation as job_template_name
+import data.aap_policy_examples.project_scm_branch_validation as branch
+
+default allowed = false
+
+allowed if {
+    trace(sprintf("job_template_name.allowed: %v", [job_template_name.allowed]))
+    trace(sprintf("branch.allowed: %v", [branch.allowed]))
+    job_template_name.allowed
+    branch.allowed
+}
+
+multistep_validation := result if {
+    result := {
+        "allowed": allowed,
+        "violations": array.concat(job_template_name.violations, branch.violations)
+    }
+}


### PR DESCRIPTION
As requested in some of the tech demos I have given, as well as to provide an example of another rego data structure, this is a simple job template naming validation option that uses pre-defined environment prefixes as opposed to the dynamically generated prefixes seen in the current policy.