### PR TITLE
Create a multiple policy example

### DIFF
--- a/10.Enforce multiple policies.md
+++ b/10.Enforce multiple policies.md
@@ -1,0 +1,91 @@
+# 1. Restrict use of an Inventory to a particular Organization
+
+## Overview
+
+Ansible Automation Platform allows users to enforce policies at multiple enforcement points, including:
+
+* **Organization Level:** Affects all job templates within an Organization.
+* **Inventory Level:** Affects all jobs using a specified Inventory.
+* **Job Template Level:** Affects jobs launched from a specific Job Template.
+
+However, as each enforcement point only allows for a single policy, combining multiple policies needs to be done on the policy server side to provide a single endpoint. This example covers the aforementioned use case.
+
+## Example Policy [aap_policy_examples/multistep_policy.rego](aap_policy_examples/multistep_policy.rego):
+
+The following policy (`multistep_policy.rego`) combines two already existing policies, the job template naming convention (`jt_naming_validation.rego`) and the project scm branch (`project_scm_branch.rego`) into a single policy that can be applied through Ansible Automation Platform.
+
+```rego
+# This policy combines two existing policies, the jt_naming_validation and the project_scm_branch_validation policy into a single policy to be enforced
+package multistep
+
+import data.aap_policy_examples.jt_naming_validation as job_template_name
+import data.aap_policy_examples.project_scm_branch_validation as branch
+
+default allowed = false
+
+allowed if {
+    trace(sprintf("job_template_name.allowed: %v", [job_template_name.allowed]))
+    trace(sprintf("branch.allowed: %v", [branch.allowed]))
+    job_template_name.allowed
+    branch.allowed
+}
+
+multistep_validation := result if {
+    result := {
+        "allowed": allowed,
+        "violations": array.concat(job_template_name.violations, branch.violations)
+    }
+}
+
+```
+
+## Enforcement Behavior
+
+When applied at different enforcement points, this policy prevents job execution accordingly:
+
+- **Job Template:** All jobs launched from the template will **ERROR**, preventing playbook execution.
+- **Inventory:** All jobs using the inventory will **ERROR**, preventing playbook, preventing playbook execution.
+- **Organization:** All jobs launch from job template that belongs to the organization will **ERROR**, preventing playbook execution.
+
+This policy can be used at any level, and depends on how organizations are used in your Ansible Automation Platform instance, and how configuration management of the platform is enforced.
+
+## Try It Yourself
+
+Take advantage of the [Rego playground](https://play.openpolicyagent.org/)!
+
+## Real World Use Case: Manage rego policy application
+
+### Scenario  
+
+As policy becomes more complex, administrators need to be able to manage their policies.  Reusability of policies across enforcement points becomes a core component of managing policy at scale.  Building piecewise blocks to create policies once would ease the administrative burden of managing policies.
+
+### Approach
+
+Consider a large environment with numerous organizations and teams.  The rego system administrators could create a handful of core policies that apply to everyone within their company, such as
+* Enforce a job template naming convention
+* Forbid superusers from running automation jobs
+
+Additionally, team policies, such as for the ops team, could be created around policies that change at this level, such as
+* Github repo validations
+* Inventory usage restrictions
+
+Finally, lifecycle-stage policies would be created, which would be differing based on dev, test or prod environments, such as
+* Project SCM branch enforcement
+* Maintenance windows
+
+Enforcing multiple policies can be chained.  This could look like (symbolically)
+
+```
+└── Ops_production_policy.rego
+    ├── company_policy.rego
+    │   ├── jt_naming_validation.rego
+    │   └── superuser_allowed_false.rego
+    ├── ops_policy.rego
+    │   ├── github_repo_validation.rego
+    │   └── restrict_inv_use_to_org.rego
+    └── ops_production.rego
+        ├── maintenance_window.rego
+        └── project_scm_branch.rego
+```
+
+This approach allows for easier management of the policies, where policies are written once and reused for different teams, environments, etc.

--- a/10.Enforce multiple policies.md
+++ b/10.Enforce multiple policies.md
@@ -1,4 +1,4 @@
-# 1. Restrict use of an Inventory to a particular Organization
+# 10. Enforce Multiple Policies
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Policy as Code allows you to define and enforce policies across your Ansible Aut
 
 - Ansible Automation Platform 2.5 or later with the `FEATURE_POLICY_AS_CODE_ENABLED` feature flag set to `True` 
   - see [Enabling Policy as Code Feature](docs/Enabling%20Policy%20as%20Code%20feature.md) for more information
+  - Note that this flag is enabled by default for Ansible Automation Platform 2.6 and later
 - An OPA server that's reachable from your AAP deployment
   - See [Deploy OPA server on OpenShift](docs/Deploy%20OPA%20server%20on%20OpenShift.md) for development and testing setup
   - See [Deploy OPA server with Podman](docs/Deploy%20OPA%20server%20with%20Podman.md) for development and testing setup
@@ -53,6 +54,7 @@ The repository includes several example policies demonstrating different use cas
    - [Only allow approved Github source repo branches](7b.Only%20allow%20certain%20Git%20branches.md) - Only allow approved source repo branches
 8. [Enforce Naming Standards](8.Enforce%20Job%20Template%20Naming%20Standards.md) - ensure Job Template name conforms to our standards
 9. [Restrict usage of an Inventory to an Organization](9.Restrict%20Inventory%20use%20to%20an%20organization.md) - restrict inventory usage by organization
+10. [Enforce multiple policies](10.Enforce%20multiple%20policies.md) - Chain multiple policies together for use in AAP
 
 Each policy example includes:
 - Detailed explanation of the use case

--- a/aap_policy_examples/multistep_policy.rego
+++ b/aap_policy_examples/multistep_policy.rego
@@ -1,0 +1,21 @@
+# This policy combines two existing policies, the jt_naming_validation and the project_scm_branch_validation policy into a single policy to be enforced
+package multistep
+
+import data.aap_policy_examples.jt_naming_validation as job_template_name
+import data.aap_policy_examples.project_scm_branch_validation as branch
+
+default allowed = false
+
+allowed if {
+    trace(sprintf("job_template_name.allowed: %v", [job_template_name.allowed]))
+    trace(sprintf("branch.allowed: %v", [branch.allowed]))
+    job_template_name.allowed
+    branch.allowed
+}
+
+multistep_validation := result if {
+    result := {
+        "allowed": allowed,
+        "violations": array.concat(job_template_name.violations, branch.violations)
+    }
+}


### PR DESCRIPTION
As per the internal slack thread on policy enforcement, this PR provides documentation and an example on how to chain imports of policies to create a "policy of policies", such that AAP can consume a single policy with multiple checks.