### PR TITLE
Add a policy example for checking for a valid URL

### DIFF
--- a/10.Check for valid url.md
+++ b/10.Check for valid url.md
@@ -1,0 +1,93 @@
+# 10. Check for valid URL
+
+## Overview
+
+This example demonstrates how to require providing a valid url, such as a git issue number, to run execution.
+
+## Example Policy [aap_policy_examples/url_check.rego](aap_policy_examples/url_check.rego):
+
+The following policy (`url_check.rego`) blocks job execution without a 200/OK URL response, and can be applied at any policy level: 
+
+```rego
+package aap_policy_examples.url_check
+
+import rego.v1
+
+# checks if the http request is 200 OK
+issue_exists if {
+    # This is set to use the source control URL of the project in AAP, and a provided extra variable, "git_issue"
+    scm_url := input.project.scm_url
+    issue_id := input.extra_vars.git_issue
+
+
+    # This has been tested with GitLab Community, and the transformation may be different for other source control providers
+    base_url := regex.replace(scm_url, "\\.git$", "")
+    target_url := sprintf("%s/-/issues/%v", [base_url, issue_id])
+
+    # Get an HTTP response code
+    response := http.send({
+        "method": "HEAD",
+        "url": target_url,
+        "timeout": "5s",
+        "tls_insecure_skip_verify": true
+    })
+    
+    # This last step evaluates to true if the response code is 200/OK, which means that issue_exists evaluates to true
+    response.status_code == 200
+}
+
+# Default to false (deny) unless issue_exists is true
+default allowed := false
+
+allowed if {
+    issue_exists
+}
+
+# Rule: violations
+# 1. Define 'denials' as the set of error messages (Partial Set Rule)
+denials contains msg if {
+    # Trigger if the issue check fails
+    not issue_exists
+    
+    # Construct a safe error message even if vars are missing
+    safe_issue := object.get(input.extra_vars, "git_issue", "missing")
+    safe_url := object.get(input.project, "scm_url", "missing")
+    
+    msg := sprintf("Git Issue #%v was not found (or did not return 200 OK) for repo: %v", [safe_issue, safe_url])
+}
+
+# 2. Define 'violations' to output the denials (Complete Rule)
+# This resolves the conflict by separating the set generation from the final output variable.
+default violations := []
+
+violations := denials
+```
+
+## Enforcement Behavior
+
+When applied at different enforcement points, this policy prevents job execution accordingly:
+
+- **Job Template:** All jobs launched from the template will **ERROR**, preventing playbook execution.
+- **Inventory:** All jobs using the inventory will **ERROR**, preventing playbook, preventing playbook execution.
+- **Organization:** All jobs launch from job template that belongs to the organization will **ERROR**, preventing playbook execution.
+
+The recommendation for this enforcement point varies, but for most, should be applied at the **Job Template** level.
+
+## Try It Yourself
+
+Take advantage of the [Rego playground](https://play.openpolicyagent.org/p/xzsz9n3yeP)!
+
+## Real World Use Case: Require a valid issue to run automation content
+
+### Scenario  
+
+Your company policy mandates that a valid change order is attached to your automation job execution.  For this example, we are requiring a valid issue number in gitlab, but the concept could be applied to various ITSMs.
+
+### Execution
+
+By requiring users to provide a valid **git_issue** number as an extra variable, the issue can be paired against the automation execution in logging stacks.  This could be a key piece of automated remediation and self-healing workflows, for instance.  This policy would be ensuring that the issue created that triggers self-healing is legitimate, and pairing the job execution artifact to the reported issue for post-mortem analysis.
+
+## How AAP Enforces the Policy  
+
+Before the job run, a URL check is sent out, which if it returns a 200/OK, showing a valid URL was constructed, the job will be allowed to run.  As this sample policy is crafted, using the git URL from the project being launched, and combining it with the issue number provided by the user, the job will only run if the URL exists, essentially ensuring that the ticket exists.
+

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The repository includes several example policies demonstrating different use cas
    - [Only allow approved Github source repo branches](7b.Only%20allow%20certain%20Git%20branches.md) - Only allow approved source repo branches
 8. [Enforce Naming Standards](8.Enforce%20Job%20Template%20Naming%20Standards.md) - ensure Job Template name conforms to our standards
 9. [Restrict usage of an Inventory to an Organization](9.Restrict%20Inventory%20use%20to%20an%20organization.md) - restrict inventory usage by organization
+10. [Check for valid URL](10.Check%20for%20valid%20url.md) - Check that a URL exists, such as an ITSM ticket
 
 Each policy example includes:
 - Detailed explanation of the use case

--- a/aap_policy_examples/url_check.rego
+++ b/aap_policy_examples/url_check.rego
@@ -1,0 +1,52 @@
+package aap_policy_examples.url_check
+
+import rego.v1
+
+# checks if the http request is 200 OK
+issue_exists if {
+    # This is set to use the source control URL of the project in AAP, and a provided extra variable, "git_issue"
+    scm_url := input.project.scm_url
+    issue_id := input.extra_vars.git_issue
+
+
+    # This has been tested with GitLab Community, and the transformation may be different for other source control providers
+    base_url := regex.replace(scm_url, "\\.git$", "")
+    target_url := sprintf("%s/-/issues/%v", [base_url, issue_id])
+
+    # Get an HTTP response code
+    response := http.send({
+        "method": "HEAD",
+        "url": target_url,
+        "timeout": "5s",
+        "tls_insecure_skip_verify": true
+    })
+    
+    # This last step evaluates to true if the response code is 200/OK, which means that issue_exists evaluates to true
+    response.status_code == 200
+}
+
+# Default to false (deny) unless issue_exists is true
+default allowed := false
+
+allowed if {
+    issue_exists
+}
+
+# Rule: violations
+# 1. Define 'denials' as the set of error messages (Partial Set Rule)
+denials contains msg if {
+    # Trigger if the issue check fails
+    not issue_exists
+    
+    # Construct a safe error message even if vars are missing
+    safe_issue := object.get(input.extra_vars, "git_issue", "missing")
+    safe_url := object.get(input.project, "scm_url", "missing")
+    
+    msg := sprintf("Git Issue #%v was not found (or did not return 200 OK) for repo: %v", [safe_issue, safe_url])
+}
+
+# 2. Define 'violations' to output the denials (Complete Rule)
+# This resolves the conflict by separating the set generation from the final output variable.
+default violations := []
+
+violations := denials


### PR DESCRIPTION
As demonstrated at Red Hat One (in this video https://youtu.be/I-Zw4rzTbKE?t=470 )
From 7:22 to 10:48, this policy example is used to show an example of checking against a URL to see if there's a valid issue.